### PR TITLE
Edit code to ignore symbols

### DIFF
--- a/lib/cipher.rb
+++ b/lib/cipher.rb
@@ -1,5 +1,5 @@
 class Cipher
-  
+
   def alphabet
     ("a".."z").to_a << " "
   end
@@ -48,6 +48,9 @@ class Cipher
 
     indices = []
     characters.each do |character|
+      if !character[/\W/].nil? && character != " "
+        indices << character
+      end
       alphabet.each do |letter|
         if character == letter
           indices << alphabet.index(letter)

--- a/lib/decrypt.rb
+++ b/lib/decrypt.rb
@@ -41,7 +41,11 @@ class Decrypt < Cipher
     decrypted_letters = []
 
     decryption_indices_in_alphabet_array(message).each do |index|
-      decrypted_letters << alphabet[index]
+      if index.is_a?(Numeric)
+        decrypted_letters << alphabet[index]
+      elsif !index.is_a?(Numeric)
+        decrypted_letters << index
+      end
     end
     decrypted_letters.join
   end

--- a/lib/decrypt.rb
+++ b/lib/decrypt.rb
@@ -13,10 +13,14 @@ class Decrypt < Cipher
     slices = []
     sliced = slice_indices(message)
     sliced.map do |slice|
-      slices << slice[0] - find_shifts[:a_shift] if !slice[0].nil?
-      slices << slice[1] - find_shifts[:b_shift] if !slice[1].nil?
-      slices << slice[2] - find_shifts[:c_shift] if !slice[2].nil?
-      slices << slice[3] - find_shifts[:d_shift] if !slice[3].nil?
+      slices << slice[0] if !slice[0].nil? && !slice[0].is_a?(Numeric)
+      slices << slice[0] - find_shifts[:a_shift] if !slice[0].nil? && slice[0].is_a?(Numeric)
+      slices << slice[1] if !slice[1].nil? && !slice[1].is_a?(Numeric)
+      slices << slice[1] - find_shifts[:b_shift] if !slice[1].nil? && slice[1].is_a?(Numeric)
+      slices << slice[2] if !slice[2].nil? && !slice[2].is_a?(Numeric)
+      slices << slice[2] - find_shifts[:c_shift] if !slice[2].nil? && slice[2].is_a?(Numeric)
+      slices << slice[3] if !slice[3].nil? && !slice[3].is_a?(Numeric)
+      slices << slice[3] - find_shifts[:d_shift] if !slice[3].nil? && slice[3].is_a?(Numeric)
     end
     slices
   end

--- a/lib/decrypt.rb
+++ b/lib/decrypt.rb
@@ -27,9 +27,9 @@ class Decrypt < Cipher
 
   def decryption_indices_in_alphabet_array(message)
     subtract_shift_from_indices(message).map do |index|
-      if index < -26
+      if index.is_a?(Numeric) && index < -26
         index % 27
-      elsif index > -26 && index.negative?
+      elsif index.is_a?(Numeric) && index > -26 && index.negative?
         27 - index.abs
       else
         index

--- a/lib/encrypt.rb
+++ b/lib/encrypt.rb
@@ -39,7 +39,7 @@ class Encrypt < Cipher
     letters = []
 
     encryption_indices_in_alphabet_array(message).each do |index|
-      if index.is_a?(Numeric)
+      if index.is_a?(Numeric) && index.is_a?(Numeric)
         letters << alphabet[index]
       elsif !index.is_a?(Numeric)
         letters << index

--- a/lib/encrypt.rb
+++ b/lib/encrypt.rb
@@ -27,7 +27,7 @@ class Encrypt < Cipher
 
   def encryption_indices_in_alphabet_array(message)
     add_shift_to_indices(message).map do |index|
-      if index > 26
+      if index.is_a?(Numeric) && index > 26
         index % 27
       else
         index
@@ -39,7 +39,7 @@ class Encrypt < Cipher
     letters = []
 
     encryption_indices_in_alphabet_array(message).each do |index|
-      if index.is_a?(Numeric) && index.is_a?(Numeric)
+      if index.is_a?(Numeric)
         letters << alphabet[index]
       elsif !index.is_a?(Numeric)
         letters << index

--- a/lib/encrypt.rb
+++ b/lib/encrypt.rb
@@ -13,10 +13,14 @@ class Encrypt < Cipher
     slices = []
     sliced = slice_indices(message)
     sliced.map do |slice|
-      slices << slice[0] + find_shifts[:a_shift] if !slice[0].nil?
-      slices << slice[1] + find_shifts[:b_shift] if !slice[1].nil?
-      slices << slice[2] + find_shifts[:c_shift] if !slice[2].nil?
-      slices << slice[3] + find_shifts[:d_shift] if !slice[3].nil?
+      slices << slice[0] if !slice[0].nil? && !slice[0].is_a?(Numeric)
+      slices << slice[0] + find_shifts[:a_shift] if !slice[0].nil? && slice[0].is_a?(Numeric)
+      slices << slice[1] if !slice[1].nil? && !slice[1].is_a?(Numeric)
+      slices << slice[1] + find_shifts[:b_shift] if !slice[1].nil? && slice[1].is_a?(Numeric)
+      slices << slice[2] if !slice[2].nil? && !slice[2].is_a?(Numeric)
+      slices << slice[2] + find_shifts[:c_shift] if !slice[2].nil? && slice[2].is_a?(Numeric)
+      slices << slice[3] if !slice[3].nil? && !slice[3].is_a?(Numeric)
+      slices << slice[3] + find_shifts[:d_shift] if !slice[3].nil? && slice[3].is_a?(Numeric)
     end
     slices
   end

--- a/lib/encrypt.rb
+++ b/lib/encrypt.rb
@@ -39,7 +39,11 @@ class Encrypt < Cipher
     letters = []
 
     encryption_indices_in_alphabet_array(message).each do |index|
-      letters << alphabet[index]
+      if index.is_a?(Numeric)
+        letters << alphabet[index]
+      elsif !index.is_a?(Numeric)
+        letters << index
+      end
     end
     letters.join
   end

--- a/test/decrypt_test.rb
+++ b/test/decrypt_test.rb
@@ -6,12 +6,12 @@ require 'date'
 
 class DecryptTest < Minitest::Test
   def setup
-    @decrypt = Decrypt.new
+    @decryption = Decrypt.new
     @encryption = Encrypt.new
   end
 
   def test_it_exists
-    assert_instance_of Decrypt, @decrypt
+    assert_instance_of Decrypt, @decryption
   end
 
   def test_it_can_return_alphabet_array
@@ -45,11 +45,11 @@ class DecryptTest < Minitest::Test
       " "
     ]
 
-    assert_equal expected, @decrypt.alphabet
+    assert_equal expected, @decryption.alphabet
   end
 
   def test_it_can_find_keys
-    @decrypt.stubs(:generate_random_key).returns("02715")
+    @decryption.stubs(:generate_random_key).returns("02715")
     expected = {
       :a_key=>2,
       :b_key=>27,
@@ -57,7 +57,7 @@ class DecryptTest < Minitest::Test
       :d_key=>15
     }
 
-    assert_equal expected, @decrypt.find_keys
+    assert_equal expected, @decryption.find_keys
   end
 
   def test_it_can_find_offsets
@@ -69,12 +69,12 @@ class DecryptTest < Minitest::Test
       :d_offset=>5
     }
 
-    assert_equal expected, @decrypt.find_offsets
+    assert_equal expected, @decryption.find_offsets
   end
 
   def test_it_can_find_shifts
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
-    @decrypt.stubs(:generate_random_key).returns("02715")
+    @decryption.stubs(:generate_random_key).returns("02715")
     expected = {
       :a_shift=>3,
       :b_shift=>27,
@@ -82,60 +82,60 @@ class DecryptTest < Minitest::Test
       :d_shift=>20
     }
 
-    assert_equal expected, @decrypt.find_shifts
+    assert_equal expected, @decryption.find_shifts
   end
 
   def test_it_can_find_message_indices
     expected = [10, 4, 3, 4, 17, 26, 14, 7, 20, 11, 22]
     sym_expected = ["!", 10, 4, 3, 4, 17, "!", 26,  14, 7, 20, 11, 22, "!"]
 
-    assert_equal expected, @decrypt.find_message_indices("keder ohulw")
-    assert_equal sym_expected, @decrypt.find_message_indices("!keder! ohulw!")
+    assert_equal expected, @decryption.find_message_indices("keder ohulw")
+    assert_equal sym_expected, @decryption.find_message_indices("!keder! ohulw!")
   end
 
   def test_it_can_slice_indices
     expected = [[10, 4, 3, 4], [17, 26, 14, 7], [20, 11, 22]]
     sym_expected = [["!", 10, 4, 3], [4, 17, "!", 26],  [14, 7, 20, 11], [22, "!"]]
 
-    assert_equal expected, @decrypt.slice_indices("keder ohulw")
-    assert_equal expected, @decrypt.slice_indices("KEDER OHULW")
-    assert_equal sym_expected, @decrypt.slice_indices("!keder! ohulw!")
+    assert_equal expected, @decryption.slice_indices("keder ohulw")
+    assert_equal expected, @decryption.slice_indices("KEDER OHULW")
+    assert_equal sym_expected, @decryption.slice_indices("!keder! ohulw!")
   end
 
   def test_it_can_subtract_shifts_from_indices
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
-    @decrypt.stubs(:generate_random_key).returns("02715")
+    @decryption.stubs(:generate_random_key).returns("02715")
     expected = [7, -23, -70, -16, 14, -1, -59, -13, 17, -16, -51]
     sym_expected = ["!", -17, -69, -17, 1, -10, "!", 6, 11, -20, -53, -9, 19, "!"]
 
-    assert_equal expected, @decrypt.subtract_shift_from_indices("keder ohulw")
-    assert_equal expected, @decrypt.subtract_shift_from_indices("KEDER OHULW")
-    assert_equal sym_expected, @decrypt.subtract_shift_from_indices("!keder! ohulw!")
+    assert_equal expected, @decryption.subtract_shift_from_indices("keder ohulw")
+    assert_equal expected, @decryption.subtract_shift_from_indices("KEDER OHULW")
+    assert_equal sym_expected, @decryption.subtract_shift_from_indices("!keder! ohulw!")
   end
 
   def test_it_can_find_decryption_indices_in_alphabet_array
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
-    @decrypt.stubs(:generate_random_key).returns("02715")
+    @decryption.stubs(:generate_random_key).returns("02715")
     expected = [7, 4, 11, 11, 14, 26, 22, 14, 17, 11, 3]
     sym_expected = ["!", 10, 12, 10, 1, 17, "!", 6, 11, 7, 1, 18, 19, "!"]
 
-    assert_equal expected, @decrypt.decryption_indices_in_alphabet_array("keder ohulw")
-    assert_equal expected, @decrypt.decryption_indices_in_alphabet_array("KEDER OHULW")
-    assert_equal sym_expected, @decrypt.decryption_indices_in_alphabet_array("!keder! ohulw!")
+    assert_equal expected, @decryption.decryption_indices_in_alphabet_array("keder ohulw")
+    assert_equal expected, @decryption.decryption_indices_in_alphabet_array("KEDER OHULW")
+    assert_equal sym_expected, @decryption.decryption_indices_in_alphabet_array("!keder! ohulw!")
   end
 
   def test_it_can_find_decrypted_letters
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
-    @decrypt.stubs(:generate_random_key).returns("02715")
+    @decryption.stubs(:generate_random_key).returns("02715")
 
-    assert_equal "hello world", @decrypt.find_decrypted_letters("keder ohulw")
-    assert_equal "hello world", @decrypt.find_decrypted_letters("KEDER OHULW")
-    assert_equal "!hello! world!", @decrypt.find_decrypted_letters("!hxeoo!tzojeg!")
+    assert_equal "hello world", @decryption.find_decrypted_letters("keder ohulw")
+    assert_equal "hello world", @decryption.find_decrypted_letters("KEDER OHULW")
+    assert_equal "!hello! world!", @decryption.find_decrypted_letters("!hxeoo!tzojeg!")
   end
 
   def test_it_can_get_decryption_hash_creation
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
-    @decrypt.stubs(:generate_random_key).returns("02715")
+    @decryption.stubs(:generate_random_key).returns("02715")
     expected = {
       decryption: "hello world",
       key: "02715",
@@ -147,9 +147,9 @@ class DecryptTest < Minitest::Test
       date: "040895"
     }
 
-    assert_equal expected, @decrypt.decryption_hash_creation("keder ohulw")
-    assert_equal expected, @decrypt.decryption_hash_creation("KEDER OHULW")
-    assert_equal sym_expected, @decrypt.decryption_hash_creation("!hxeoo!tzojeg!")
+    assert_equal expected, @decryption.decryption_hash_creation("keder ohulw")
+    assert_equal expected, @decryption.decryption_hash_creation("KEDER OHULW")
+    assert_equal sym_expected, @decryption.decryption_hash_creation("!hxeoo!tzojeg!")
   end
 
   def test_it_can_decrypt_message_with_key_and_date
@@ -164,9 +164,9 @@ class DecryptTest < Minitest::Test
       date: "040895"
     }
 
-    assert_equal expected, @decrypt.decrypt("keder ohulw", "02715", "040895")
-    assert_equal expected, @decrypt.decrypt("KEDER OHULW", "02715", "040895")
-    assert_equal sym_expected, @decrypt.decrypt(("!hxeoo!tzojeg!"), "02715", "040895")
+    assert_equal expected, @decryption.decrypt("keder ohulw", "02715", "040895")
+    assert_equal expected, @decryption.decrypt("KEDER OHULW", "02715", "040895")
+    assert_equal sym_expected, @decryption.decrypt(("!hxeoo!tzojeg!"), "02715", "040895")
   end
 
   def test_it_can_decrypt_message_with_key
@@ -178,6 +178,6 @@ class DecryptTest < Minitest::Test
       date: "040895"
     }
 
-    assert_equal expected, @decrypt.decrypt(encrypted[:encryption], "02715")
+    assert_equal expected, @decryption.decrypt(encrypted[:encryption], "02715")
   end
 end

--- a/test/decrypt_test.rb
+++ b/test/decrypt_test.rb
@@ -85,41 +85,41 @@ class DecryptTest < Minitest::Test
 
   def test_it_can_find_message_indices
     expected = [10, 4, 3, 4, 17, 26, 14, 7, 20, 11, 22]
-    sym_expected = ["!", 10, 4, 3, 4, 17, 26,"!",  14, 7, 20, 11, 22, "!"]
+    sym_expected = ["!", 10, 4, 3, 4, 17, "!", 26,  14, 7, 20, 11, 22, "!"]
 
     assert_equal expected, @decrypt.find_message_indices("keder ohulw")
-    assert_equal sym_expected, @decrypt.find_message_indices("!keder !ohulw!")
+    assert_equal sym_expected, @decrypt.find_message_indices("!keder! ohulw!")
   end
 
   def test_it_can_slice_indices
     expected = [[10, 4, 3, 4], [17, 26, 14, 7], [20, 11, 22]]
-    sym_expected = [["!", 10, 4, 3], [4, 17, 26,"!"],  [14, 7, 20, 11], [22, "!"]]
+    sym_expected = [["!", 10, 4, 3], [4, 17, "!", 26],  [14, 7, 20, 11], [22, "!"]]
 
     assert_equal expected, @decrypt.slice_indices("keder ohulw")
     assert_equal expected, @decrypt.slice_indices("KEDER OHULW")
-    assert_equal sym_expected, @decrypt.slice_indices("!keder !ohulw!")
+    assert_equal sym_expected, @decrypt.slice_indices("!keder! ohulw!")
   end
 
   def test_it_can_subtract_shifts_from_indices
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
     @decrypt.stubs(:generate_random_key).returns("02715")
     expected = [7, -23, -70, -16, 14, -1, -59, -13, 17, -16, -51]
-    sym_expected = ["!", -17, -69, -17, 1, -10, -47, "!", 11, -20, -53, -9, 19, "!"]
+    sym_expected = ["!", -17, -69, -17, 1, -10, "!", 6, 11, -20, -53, -9, 19, "!"]
 
     assert_equal expected, @decrypt.subtract_shift_from_indices("keder ohulw")
     assert_equal expected, @decrypt.subtract_shift_from_indices("KEDER OHULW")
-    assert_equal sym_expected, @decrypt.subtract_shift_from_indices("!keder !ohulw!")
+    assert_equal sym_expected, @decrypt.subtract_shift_from_indices("!keder! ohulw!")
   end
 
   def test_it_can_find_decryption_indices_in_alphabet_array
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
     @decrypt.stubs(:generate_random_key).returns("02715")
     expected = [7, 4, 11, 11, 14, 26, 22, 14, 17, 11, 3]
-    sym_expected = ["!", 10, 12, 10, 1, 17, 7, "!", 11, 7, 1, 18, 19, "!"]
+    sym_expected = ["!", 10, 12, 10, 1, 17, "!", 6, 11, 7, 1, 18, 19, "!"]
 
     assert_equal expected, @decrypt.decryption_indices_in_alphabet_array("keder ohulw")
     assert_equal expected, @decrypt.decryption_indices_in_alphabet_array("KEDER OHULW")
-    assert_equal sym_expected, @decrypt.decryption_indices_in_alphabet_array("!keder !ohulw!")
+    assert_equal sym_expected, @decrypt.decryption_indices_in_alphabet_array("!keder! ohulw!")
   end
 
   def test_it_can_find_decrypted_letters
@@ -139,9 +139,15 @@ class DecryptTest < Minitest::Test
       key: "02715",
       date: "040895"
     }
+    sym_expected = {
+      decryption: "!hello! world!",
+      key: "02715",
+      date: "040895"
+    }
 
     assert_equal expected, @decrypt.decryption_hash_creation("keder ohulw")
     assert_equal expected, @decrypt.decryption_hash_creation("KEDER OHULW")
+    assert_equal sym_expected, @decrypt.decryption_hash_creation("!hxeoo!tzojeg!")
   end
 
   def test_it_can_decrypt_message_with_key_and_date
@@ -150,9 +156,15 @@ class DecryptTest < Minitest::Test
       key: "02715",
       date: "040895"
     }
+    sym_expected = {
+      decryption: "!hello! world!",
+      key: "02715",
+      date: "040895"
+    }
 
     assert_equal expected, @decrypt.decrypt("keder ohulw", "02715", "040895")
     assert_equal expected, @decrypt.decrypt("KEDER OHULW", "02715", "040895")
+    assert_equal sym_expected, @decrypt.decrypt(("!hxeoo!tzojeg!"), "02715", "040895")
   end
 
   def test_it_can_decrypt_message_with_key

--- a/test/decrypt_test.rb
+++ b/test/decrypt_test.rb
@@ -1,11 +1,13 @@
 require_relative 'test_helper'
 require 'mocha/minitest'
 require './lib/decrypt'
+require './lib/encrypt'
 require 'date'
 
 class DecryptTest < Minitest::Test
   def setup
     @decrypt = Decrypt.new
+    @encryption = Encrypt.new
   end
 
   def test_it_exists
@@ -168,15 +170,14 @@ class DecryptTest < Minitest::Test
   end
 
   def test_it_can_decrypt_message_with_key
-    skip
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
-    encrypted = @enigma.encrypt("hello world", "02715")
+    encrypted = @encryption.encrypt("hello world", "02715")
     expected = {
       decryption: "hello world",
       key: "02715",
       date: "040895"
     }
 
-    assert_equal expected, @enigma.decrypt(encrypted[:encryption], "02715")
+    assert_equal expected, @decrypt.decrypt(encrypted[:encryption], "02715")
   end
 end

--- a/test/decrypt_test.rb
+++ b/test/decrypt_test.rb
@@ -85,32 +85,41 @@ class DecryptTest < Minitest::Test
 
   def test_it_can_find_message_indices
     expected = [10, 4, 3, 4, 17, 26, 14, 7, 20, 11, 22]
+    sym_expected = ["!", 10, 4, 3, 4, 17, 26,"!",  14, 7, 20, 11, 22, "!"]
 
     assert_equal expected, @decrypt.find_message_indices("keder ohulw")
+    assert_equal sym_expected, @decrypt.find_message_indices("!keder !ohulw!")
   end
 
   def test_it_can_slice_indices
     expected = [[10, 4, 3, 4], [17, 26, 14, 7], [20, 11, 22]]
+    sym_expected = [["!", 10, 4, 3], [4, 17, 26,"!"],  [14, 7, 20, 11], [22, "!"]]
 
     assert_equal expected, @decrypt.slice_indices("keder ohulw")
+    assert_equal expected, @decrypt.slice_indices("KEDER OHULW")
+    assert_equal sym_expected, @decrypt.slice_indices("!keder !ohulw!")
   end
 
   def test_it_can_subtract_shifts_from_indices
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
     @decrypt.stubs(:generate_random_key).returns("02715")
     expected = [7, -23, -70, -16, 14, -1, -59, -13, 17, -16, -51]
+    sym_expected = ["!", -17, -69, -17, 1, -10, -47, "!", 11, -20, -53, -9, 19, "!"]
 
     assert_equal expected, @decrypt.subtract_shift_from_indices("keder ohulw")
     assert_equal expected, @decrypt.subtract_shift_from_indices("KEDER OHULW")
+    assert_equal sym_expected, @decrypt.subtract_shift_from_indices("!keder !ohulw!")
   end
 
   def test_it_can_find_decryption_indices_in_alphabet_array
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
     @decrypt.stubs(:generate_random_key).returns("02715")
     expected = [7, 4, 11, 11, 14, 26, 22, 14, 17, 11, 3]
+    sym_expected = ["!", -17, -69, -17, 1, -10, -47, "!", 11, -20, -53, -9, 19, "!"]
 
     assert_equal expected, @decrypt.decryption_indices_in_alphabet_array("keder ohulw")
     assert_equal expected, @decrypt.decryption_indices_in_alphabet_array("KEDER OHULW")
+    assert_equal sym_expected, @decrypt.decryption_indices_in_alphabet_array("!keder !ohulw!")
   end
 
   def test_it_can_find_decrypted_letters
@@ -146,6 +155,7 @@ class DecryptTest < Minitest::Test
   end
 
   def test_it_can_decrypt_message_with_key
+    skip
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
     encrypted = @enigma.encrypt("hello world", "02715")
     expected = {

--- a/test/decrypt_test.rb
+++ b/test/decrypt_test.rb
@@ -128,6 +128,7 @@ class DecryptTest < Minitest::Test
 
     assert_equal "hello world", @decrypt.find_decrypted_letters("keder ohulw")
     assert_equal "hello world", @decrypt.find_decrypted_letters("KEDER OHULW")
+    assert_equal "!hello! world!", @decrypt.find_decrypted_letters("!hxeoo!tzojeg!")
   end
 
   def test_it_can_get_decryption_hash_creation

--- a/test/decrypt_test.rb
+++ b/test/decrypt_test.rb
@@ -115,7 +115,7 @@ class DecryptTest < Minitest::Test
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
     @decrypt.stubs(:generate_random_key).returns("02715")
     expected = [7, 4, 11, 11, 14, 26, 22, 14, 17, 11, 3]
-    sym_expected = ["!", -17, -69, -17, 1, -10, -47, "!", 11, -20, -53, -9, 19, "!"]
+    sym_expected = ["!", 10, 12, 10, 1, 17, 7, "!", 11, 7, 1, 18, 19, "!"]
 
     assert_equal expected, @decrypt.decryption_indices_in_alphabet_array("keder ohulw")
     assert_equal expected, @decrypt.decryption_indices_in_alphabet_array("KEDER OHULW")

--- a/test/encrypt_test.rb
+++ b/test/encrypt_test.rb
@@ -84,35 +84,43 @@ class EncryptTest < Minitest::Test
   end
 
   def test_it_can_find_message_indices
-    encryption_expected = [7, 4, 11, 11, 14, 26, 22, 14, 17, 11, 3]
+    expected = [7, 4, 11, 11, 14, 26, 22, 14, 17, 11, 3]
+    sym_expected = ["!", 7, 4, 11, 11, 14, "!", 26, 22, 14, 17, 11, 3, "!"]
 
-    assert_equal encryption_expected, @encrypt.find_message_indices("hello world")
-    assert_equal encryption_expected, @encrypt.find_message_indices("HELLO WORLD")
+    assert_equal expected, @encrypt.find_message_indices("hello world")
+    assert_equal expected, @encrypt.find_message_indices("HELLO WORLD")
+    assert_equal sym_expected, @encrypt.find_message_indices("!HELLO! WORLD!")
   end
 
   def test_it_can_slice_indices
-    encryption_expected = [[7, 4, 11, 11], [14, 26, 22, 14], [17, 11, 3]]
+    expected = [[7, 4, 11, 11], [14, 26, 22, 14], [17, 11, 3]]
+    sym_expected = [["!", 7, 4, 11], [11, 14, "!", 26], [22, 14, 17, 11], [3, "!"]]
 
-    assert_equal encryption_expected, @encrypt.slice_indices("hello world")
-    assert_equal encryption_expected, @encrypt.slice_indices("HELLO WORLD")
+    assert_equal expected, @encrypt.slice_indices("hello world")
+    assert_equal expected, @encrypt.slice_indices("HELLO WORLD")
+    assert_equal sym_expected, @encrypt.slice_indices("!HELLO! WORLD!")
   end
 
   def test_it_can_add_shift_to_indices
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
     @encrypt.stubs(:generate_random_key).returns("02715")
     expected = [10, 31, 84, 31, 17, 53, 95, 34, 20, 38, 76]
+    sym_expected = ["!", 34, 77, 31, 14, 41, "!", 46, 25, 41, 90, 31, 6, "!"]
 
     assert_equal expected, @encrypt.add_shift_to_indices("hello world")
     assert_equal expected, @encrypt.add_shift_to_indices("HELLO WORLD")
+    assert_equal sym_expected, @encrypt.add_shift_to_indices("!HELLO! WORLD!")
   end
 
   def test_it_can_find_encryption_indices_in_alphabet_array_range
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
     @encrypt.stubs(:generate_random_key).returns("02715")
     expected = [10, 4, 3, 4, 17, 26, 14, 7, 20, 11, 22]
+    sym_expected = ["!", 7, 23, 4, 14, 14, "!", 19, 25, 14, 9, 4, 6, "!"]
 
     assert_equal expected, @encrypt.encryption_indices_in_alphabet_array("hello world")
     assert_equal expected, @encrypt.encryption_indices_in_alphabet_array("HELLO WORLD")
+    assert_equal sym_expected, @encrypt.encryption_indices_in_alphabet_array("!HELLO! WORLD!")
   end
 
   def test_it_can_find_encryted_letters
@@ -121,6 +129,7 @@ class EncryptTest < Minitest::Test
 
     assert_equal "keder ohulw", @encrypt.find_encryted_letters("hello world")
     assert_equal "keder ohulw", @encrypt.find_encryted_letters("HELLO WORLD")
+    assert_equal "!hxeoo!tzojeg!", @encrypt.find_encryted_letters("!HELLO! WORLD!")
   end
 
   def test_it_can_create_encryption_hash_creation
@@ -131,9 +140,15 @@ class EncryptTest < Minitest::Test
       :key=>"02715",
       :date=>"040895"
     }
+    sym_expected = {
+      :encryption=>"!hxeoo!tzojeg!",
+      :key=>"02715",
+      :date=>"040895"
+    }
 
     assert_equal expected, @encrypt.encryption_hash_creation("hello world")
     assert_equal expected, @encrypt.encryption_hash_creation("HELLO WORLD")
+    assert_equal sym_expected, @encrypt.encryption_hash_creation("!HELLO! WORLD!")
   end
 
   def test_test_it_can_encrypt_message_with_key_and_date

--- a/test/encrypt_test.rb
+++ b/test/encrypt_test.rb
@@ -5,11 +5,11 @@ require 'date'
 
 class EncryptTest < Minitest::Test
   def setup
-    @encrypt = Encrypt.new
+    @encryption = Encrypt.new
   end
 
   def test_it_exists
-    assert_instance_of Encrypt, @encrypt
+    assert_instance_of Encrypt, @encryption
   end
 
   def test_it_can_return_alphabet_array
@@ -43,11 +43,11 @@ class EncryptTest < Minitest::Test
       " "
     ]
 
-    assert_equal expected, @encrypt.alphabet
+    assert_equal expected, @encryption.alphabet
   end
 
   def test_it_can_find_keys
-    @encrypt.stubs(:generate_random_key).returns("02715")
+    @encryption.stubs(:generate_random_key).returns("02715")
     expected = {
       :a_key=>2,
       :b_key=>27,
@@ -55,7 +55,7 @@ class EncryptTest < Minitest::Test
       :d_key=>15
     }
 
-    assert_equal expected, @encrypt.find_keys
+    assert_equal expected, @encryption.find_keys
   end
 
   def test_it_can_find_offsets
@@ -67,12 +67,12 @@ class EncryptTest < Minitest::Test
       :d_offset=>5
     }
 
-    assert_equal expected, @encrypt.find_offsets
+    assert_equal expected, @encryption.find_offsets
   end
 
   def test_it_can_find_shifts
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
-    @encrypt.stubs(:generate_random_key).returns("02715")
+    @encryption.stubs(:generate_random_key).returns("02715")
     expected = {
       :a_shift=>3,
       :b_shift=>27,
@@ -80,61 +80,61 @@ class EncryptTest < Minitest::Test
       :d_shift=>20
     }
 
-    assert_equal expected, @encrypt.find_shifts
+    assert_equal expected, @encryption.find_shifts
   end
 
   def test_it_can_find_message_indices
     expected = [7, 4, 11, 11, 14, 26, 22, 14, 17, 11, 3]
     sym_expected = ["!", 7, 4, 11, 11, 14, "!", 26, 22, 14, 17, 11, 3, "!"]
 
-    assert_equal expected, @encrypt.find_message_indices("hello world")
-    assert_equal expected, @encrypt.find_message_indices("HELLO WORLD")
-    assert_equal sym_expected, @encrypt.find_message_indices("!HELLO! WORLD!")
+    assert_equal expected, @encryption.find_message_indices("hello world")
+    assert_equal expected, @encryption.find_message_indices("HELLO WORLD")
+    assert_equal sym_expected, @encryption.find_message_indices("!HELLO! WORLD!")
   end
 
   def test_it_can_slice_indices
     expected = [[7, 4, 11, 11], [14, 26, 22, 14], [17, 11, 3]]
     sym_expected = [["!", 7, 4, 11], [11, 14, "!", 26], [22, 14, 17, 11], [3, "!"]]
 
-    assert_equal expected, @encrypt.slice_indices("hello world")
-    assert_equal expected, @encrypt.slice_indices("HELLO WORLD")
-    assert_equal sym_expected, @encrypt.slice_indices("!HELLO! WORLD!")
+    assert_equal expected, @encryption.slice_indices("hello world")
+    assert_equal expected, @encryption.slice_indices("HELLO WORLD")
+    assert_equal sym_expected, @encryption.slice_indices("!HELLO! WORLD!")
   end
 
   def test_it_can_add_shift_to_indices
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
-    @encrypt.stubs(:generate_random_key).returns("02715")
+    @encryption.stubs(:generate_random_key).returns("02715")
     expected = [10, 31, 84, 31, 17, 53, 95, 34, 20, 38, 76]
     sym_expected = ["!", 34, 77, 31, 14, 41, "!", 46, 25, 41, 90, 31, 6, "!"]
 
-    assert_equal expected, @encrypt.add_shift_to_indices("hello world")
-    assert_equal expected, @encrypt.add_shift_to_indices("HELLO WORLD")
-    assert_equal sym_expected, @encrypt.add_shift_to_indices("!HELLO! WORLD!")
+    assert_equal expected, @encryption.add_shift_to_indices("hello world")
+    assert_equal expected, @encryption.add_shift_to_indices("HELLO WORLD")
+    assert_equal sym_expected, @encryption.add_shift_to_indices("!HELLO! WORLD!")
   end
 
   def test_it_can_find_encryption_indices_in_alphabet_array_range
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
-    @encrypt.stubs(:generate_random_key).returns("02715")
+    @encryption.stubs(:generate_random_key).returns("02715")
     expected = [10, 4, 3, 4, 17, 26, 14, 7, 20, 11, 22]
     sym_expected = ["!", 7, 23, 4, 14, 14, "!", 19, 25, 14, 9, 4, 6, "!"]
 
-    assert_equal expected, @encrypt.encryption_indices_in_alphabet_array("hello world")
-    assert_equal expected, @encrypt.encryption_indices_in_alphabet_array("HELLO WORLD")
-    assert_equal sym_expected, @encrypt.encryption_indices_in_alphabet_array("!HELLO! WORLD!")
+    assert_equal expected, @encryption.encryption_indices_in_alphabet_array("hello world")
+    assert_equal expected, @encryption.encryption_indices_in_alphabet_array("HELLO WORLD")
+    assert_equal sym_expected, @encryption.encryption_indices_in_alphabet_array("!HELLO! WORLD!")
   end
 
   def test_it_can_find_encryted_letters
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
-    @encrypt.stubs(:generate_random_key).returns("02715")
+    @encryption.stubs(:generate_random_key).returns("02715")
 
-    assert_equal "keder ohulw", @encrypt.find_encryted_letters("hello world")
-    assert_equal "keder ohulw", @encrypt.find_encryted_letters("HELLO WORLD")
-    assert_equal "!hxeoo!tzojeg!", @encrypt.find_encryted_letters("!HELLO! WORLD!")
+    assert_equal "keder ohulw", @encryption.find_encryted_letters("hello world")
+    assert_equal "keder ohulw", @encryption.find_encryted_letters("HELLO WORLD")
+    assert_equal "!hxeoo!tzojeg!", @encryption.find_encryted_letters("!HELLO! WORLD!")
   end
 
   def test_it_can_create_encryption_hash_creation
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
-    @encrypt.stubs(:generate_random_key).returns("02715")
+    @encryption.stubs(:generate_random_key).returns("02715")
     expected = {
       :encryption=>"keder ohulw",
       :key=>"02715",
@@ -146,9 +146,9 @@ class EncryptTest < Minitest::Test
       :date=>"040895"
     }
 
-    assert_equal expected, @encrypt.encryption_hash_creation("hello world")
-    assert_equal expected, @encrypt.encryption_hash_creation("HELLO WORLD")
-    assert_equal sym_expected, @encrypt.encryption_hash_creation("!HELLO! WORLD!")
+    assert_equal expected, @encryption.encryption_hash_creation("hello world")
+    assert_equal expected, @encryption.encryption_hash_creation("HELLO WORLD")
+    assert_equal sym_expected, @encryption.encryption_hash_creation("!HELLO! WORLD!")
   end
 
   def test_test_it_can_encrypt_message_with_key_and_date
@@ -158,8 +158,8 @@ class EncryptTest < Minitest::Test
         date: "040895"
       }
 
-    assert_equal expected, @encrypt.encrypt("hello world", "02715", "040895")
-    assert_equal expected, @encrypt.encrypt("HELLO WORLD", "02715", "040895")
+    assert_equal expected, @encryption.encrypt("hello world", "02715", "040895")
+    assert_equal expected, @encryption.encrypt("HELLO WORLD", "02715", "040895")
   end
 
   def test_it_can_encrypt_message_with_key
@@ -169,14 +169,14 @@ class EncryptTest < Minitest::Test
         key: "02715",
         date: "280220"
       }
-    encrypted = @encrypt.encrypt("hello world", "02715")
-    encrypted = @encrypt.encrypt("HELLO WORLD", "02715")
+    encrypted = @encryption.encrypt("hello world", "02715")
+    encrypted = @encryption.encrypt("HELLO WORLD", "02715")
 
     assert_equal expected, encrypted
   end
 
   def test_it_can_encrypt_message_with_random_key
-    @encrypt.stubs(:generate_random_key).returns("02715")
+    @encryption.stubs(:generate_random_key).returns("02715")
     Date.stubs(:today).returns(Date.new(1995, 8, 4))
     expected = {
         encryption: "keder ohulw",
@@ -184,7 +184,7 @@ class EncryptTest < Minitest::Test
         date: "040895"
       }
 
-    assert_equal expected, @encrypt.encrypt("hello world")
-    assert_equal expected, @encrypt.encrypt("HELLO WORLD")
+    assert_equal expected, @encryption.encrypt("hello world")
+    assert_equal expected, @encryption.encrypt("HELLO WORLD")
   end
 end


### PR DESCRIPTION
Added to the following methods to ignore symbols that are passed in.


`find_message_indices`

`add_shift_from_indices`/`subtract_shift_from_indices`

`encryption_indices_in_alphabet_array`/`decryption_indices_in_alphabet_array`

`find_encrypted_letters`/`find_decrypted_letters`